### PR TITLE
[patch] [SelectMenu] Allow configuration of all react-select props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apparena-patterns",
-  "version": "1.2.20",
+  "version": "1.2.21",
   "license": "MIT",
   "description": "Styleguide and patterns of App-Arena.com",
   "keywords": [

--- a/source/_patterns/00-atoms/forms/select-menu/index.js
+++ b/source/_patterns/00-atoms/forms/select-menu/index.js
@@ -105,6 +105,7 @@ export default class SelectMenu extends ReactComponent {
                         backspaceToRemoveMessage={this.props.backspaceToRemoveMessage}
                         noResultsText={this.props.noResultsText}
                         disabled={this.props.disabled}
+                        {...this.props}
                     />
                 </div>
             );
@@ -128,6 +129,7 @@ export default class SelectMenu extends ReactComponent {
                     backspaceToRemoveMessage={this.props.backspaceToRemoveMessage}
                     noResultsText={this.props.noResultsText}
                     disabled={this.props.disabled}
+                    {...this.props}
                 />
             </div>
         );

--- a/source/_patterns/00-atoms/forms/select-menu/index.js
+++ b/source/_patterns/00-atoms/forms/select-menu/index.js
@@ -86,50 +86,55 @@ export default class SelectMenu extends ReactComponent {
     };
 
     render() {
-        if (this.props.creatable) {
+        const {creatable, name, id, defaultValue, options, onChange, multi, clearable, autoBlur, clearAllText,
+            clearValueText, placeholder, searchingText, backspaceToRemoveMessage, noResultsText, disabled, autofocus,
+            ...props} = this.props;
+
+        if (creatable) {
             return (
                 <div className={cx('input-group', styles.select)}>
                     <Select.Creatable
-                        name={this.props.name}
-                        id={this.props.id}
-                        value={this.props.defaultValue}
-                        options={this.props.options}
-                        onChange={this.props.onChange}
-                        multi={this.props.multi}
-                        clearable={this.props.clearable}
-                        autoBlur={this.props.autoBlur}
-                        clearAllText={this.props.clearAllText}
-                        clearValueText={this.props.clearValueText}
-                        placeholder={this.props.placeholder}
-                        searchingText={this.props.searchingText}
-                        backspaceToRemoveMessage={this.props.backspaceToRemoveMessage}
-                        noResultsText={this.props.noResultsText}
-                        disabled={this.props.disabled}
-                        {...this.props}
+                        name={name}
+                        id={id}
+                        value={defaultValue}
+                        options={options}
+                        onChange={onChange}
+                        multi={multi}
+                        clearable={clearable}
+                        autoBlur={autoBlur}
+                        clearAllText={clearAllText}
+                        clearValueText={clearValueText}
+                        placeholder={placeholder}
+                        searchingText={searchingText}
+                        backspaceToRemoveMessage={backspaceToRemoveMessage}
+                        noResultsText={noResultsText}
+                        disabled={disabled}
+                        {...props}
                     />
                 </div>
             );
         }
+
         return (
             <div className={cx('input-group', styles.select)}>
                 <Select
-                    name={this.props.name}
-                    id={this.props.id}
-                    value={this.props.defaultValue}
-                    options={this.props.options}
-                    onChange={this.props.onChange}
-                    multi={this.props.multi}
-                    autofocus={this.props.autofocus}
-                    clearable={this.props.clearable}
-                    autoBlur={this.props.autoBlur}
-                    clearAllText={this.props.clearAllText}
-                    clearValueText={this.props.clearValueText}
-                    placeholder={this.props.placeholder}
-                    searchingText={this.props.searchingText}
-                    backspaceToRemoveMessage={this.props.backspaceToRemoveMessage}
-                    noResultsText={this.props.noResultsText}
-                    disabled={this.props.disabled}
-                    {...this.props}
+                    name={name}
+                    id={id}
+                    value={defaultValue}
+                    options={options}
+                    onChange={onChange}
+                    multi={multi}
+                    autofocus={autofocus}
+                    clearable={clearable}
+                    autoBlur={autoBlur}
+                    clearAllText={clearAllText}
+                    clearValueText={clearValueText}
+                    placeholder={placeholder}
+                    searchingText={searchingText}
+                    backspaceToRemoveMessage={backspaceToRemoveMessage}
+                    noResultsText={noResultsText}
+                    disabled={disabled}
+                    {...props}
                 />
             </div>
         );


### PR DESCRIPTION
With this patch you can now configure the [react-select](https://github.com/JedWatson/react-select) component completely. There are a lot of configuration options and in my opinion limiting them to a select few will lead to problems in the future.