### PR TITLE
[patch] Ensure bootstrap beta 1 is installed by package managers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apparena-patterns",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "license": "MIT",
   "description": "Styleguide and patterns of App-Arena.com",
   "keywords": [
@@ -42,7 +42,7 @@
   "dependencies": {
     "axios": "^0.15.3",
     "babel-polyfill": "^6.16.0",
-    "bootstrap": "^4.0.0-beta",
+    "bootstrap": "4.0.0-beta",
     "classnames": "^2.2.5",
     "clipboard": "^1.6.1",
     "copy-webpack-plugin": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1904,9 +1904,9 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-bootstrap@^4.0.0-beta:
-  version "4.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0-beta.2.tgz#4d67d2aa2219f062cd90bc1247e6747b9e8fd051"
+bootstrap@4.0.0-beta:
+  version "4.0.0-beta"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0-beta.tgz#dc5928175d2e71310bc668cf9e05a907211b72a6"
 
 boxen@^1.2.1:
   version "1.2.2"


### PR DESCRIPTION
For compatibility between App-Arena products the bootstrap version has to be the same across the board.  
