### PR TITLE
[patch] Allow defining addon position for InputGroups

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apparena-patterns",
-  "version": "1.2.22",
+  "version": "1.2.23",
   "license": "MIT",
   "description": "Styleguide and patterns of App-Arena.com",
   "keywords": [

--- a/source/_patterns/01-molecules/input-group/input-group.js
+++ b/source/_patterns/01-molecules/input-group/input-group.js
@@ -6,7 +6,7 @@ import styles from './input-group.scss';
 function InputGroup({className, children, addon, addonPosition, id, ...props}) {
     props.className = cx(styles['input-group'], className);
 
-    if (addonPosition === undefined || addonPosition === 'left') {
+    if (addonPosition === 'left') {
         return (
             <div {...props} >
                 <span className={styles['input-group-addon']} id={id}>{addon}</span>
@@ -34,6 +34,10 @@ InputGroup.propTypes = {
     addon: PropTypes.node,
     addonPosition: PropTypes.oneOf(ADDON_POSITIONS),
     id: PropTypes.string
+};
+
+InputGroup.defaultProps = {
+    addonPosition: 'left'
 };
 
 export default InputGroup;

--- a/source/_patterns/01-molecules/input-group/input-group.js
+++ b/source/_patterns/01-molecules/input-group/input-group.js
@@ -3,21 +3,36 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import styles from './input-group.scss';
 
-function InputGroup({className, children, addon, id, ...props}) {
+function InputGroup({className, children, addon, addonPosition, id, ...props}) {
     props.className = cx(styles['input-group'], className);
 
-    return (
-        <div {...props} >
-            <span className={styles['input-group-addon']} id={id}>{addon}</span>
-            {children}
-        </div>
-    );
+    if (addonPosition === undefined || addonPosition === 'left') {
+        return (
+            <div {...props} >
+                <span className={styles['input-group-addon']} id={id}>{addon}</span>
+                {children}
+            </div>
+        );
+    } else if (addonPosition === 'right') {
+        return (
+            <div {...props} >
+                {children}
+                <span className={styles['input-group-addon']} id={id}>{addon}</span>
+            </div>
+        );
+    }
 }
+
+const ADDON_POSITIONS = [
+    'left',
+    'right'
+];
 
 InputGroup.propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
     addon: PropTypes.node,
+    addonPosition: PropTypes.oneOf(ADDON_POSITIONS),
     id: PropTypes.string
 };
 


### PR DESCRIPTION
Using an InputGroup for a price field is not viable at the moment because the addon will always be on the left side. While this works for the dollar, currencies like the euro aren't technically correct when written like €2.5  
This change allows choosing the addon position manually. 